### PR TITLE
完了報告の修正

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -8,7 +8,7 @@ $(function(){
               ${message.user_name}
             </div>
             <div class="upper-message__date">
-              ${message.date}
+              ${ message.created_at}
             </div>
           </div>
           <div class="lower-meesage">

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,13 +22,23 @@
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-
       #chat-group-users.js-add-user
         .chat-group-user.clearfix.js-chat-member#chat-group-user-8
           %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
           %p.chat-group-user__name= current_user.name
 
+    .chat-group-form__field--right
+      #chat-group-users
+        - @group.users.each do |user|
+          #chat-group-user-8.chat-group-user.clearfix.js-chat-member
+            %input{name: 'group[user_ids][]', type: 'hidden', value: "#{ user.id }"}
+            %p.chat-group-user__name
+              = user.name
+            %p.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right
       = f.submit class: 'chat-group-form__action-btn'
+


### PR DESCRIPTION
# what
1.メッセージの日付を正常に表示出来る様に修正。
2. 編集ページに飛んだ時に、既存のメンバー全員が「チャットメンバー」に表示される様に修正。

#why
chat-spaceに不具合があった為、修正を行った。